### PR TITLE
Add settings for various search query parameters.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -29,9 +29,25 @@ export class GoogleSearchController {
     }
 
     private static showHTMLWindow(phrase: string) {
-        let uriphrase = encodeURI(phrase);
-        let query = `q=${uriphrase}&oq=${uriphrase}&sourceid=chrome&ie=UTF-8`;
-        let previewUri = Uri.parse(`${GoogleSearchProvider.SCHEME}://google/search.html?${query}`);
+        const config = workspace.getConfiguration("google-search-ext");
+        const parameterConfigMapping: [string, string][] = [
+            ["hl", "interface-language"],
+            ["cr", "country"],
+            ["lr", "language"],
+        ];
+        const customQuery = config.get<string>("custom-query");
+
+        const uriphrase = encodeURI(phrase);
+        const query = [
+                `q=${uriphrase}`,
+                `oq=${uriphrase}`,
+                'sourceid=chrome',
+                'ie=UTF-8'
+            ]
+            .concat(parameterConfigMapping.map(([p, name]) => `${p}=${config.get<string>(name)}`))
+            .concat(customQuery ? [customQuery] : [])
+            .join("&");
+        const previewUri = Uri.parse(`${GoogleSearchProvider.SCHEME}://google/search.html?${query}`);
 
         return commands.executeCommand(
             "vscode.previewHtml",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,28 @@
 				"command": "google-search-ext.searchGoogle",
 				"group": "navigation"
 			}]
-		}
+		},
+		"configuration": [{
+			"title": "Google Search",
+			"properties": {
+				"google-search-ext.interface-language": {
+					"type": "string",
+					"description": "Sets the interface language parameter ('hl') of the Google query. Commonly a two letter code. Values list: https://developers.google.com/custom-search/docs/xml_results_appendices#interfaceLanguages"
+				},
+				"google-search-ext.language": {
+					"type": "string",
+					"description": "Sets the parameter limiting results by language ('lr') of the Google query. Should be a value of the format 'lang_<2-letter-lowercase-code>', e.g. lang_de for German. Values list: https://developers.google.com/custom-search/docs/xml_results_appendices#languageCollections"
+				},
+				"google-search-ext.country": {
+					"type": "string",
+					"description": "Sets the parameter limiting results by country ('cr') of the Google query. Should be a value of the format 'country<2-letter-uppercase-code>', e.g. countryFR for France. Values list: https://developers.google.com/custom-search/docs/xml_results_appendices#countryCollections"
+				},
+				"google-search-ext.custom-query": {
+					"type": "string",
+					"description": "Anything that should be added to the query string of the URL. E.g. 'num=10&as_qdr=3d', which limits the number of results to 10 and sets the date range to the last three days. Documentation on available parameters: https://developers.google.com/custom-search/docs/xml_results#wsQueryTerms"
+				}
+			}
+		}]
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
The added settings are listed in the package file. Among other things this partially addresses issue #3 by giving more control over the query string construction.